### PR TITLE
Update GitHub owner to duynhlab

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for duynhlab/wolfi-images
+# Docs: https://docs.github.com/articles/about-code-owners
+# Each line maps a path pattern to its owner(s); the last matching pattern wins.
+
+# Default owner for everything in the repo
+*               @duynhlab
+
+# CI / release pipeline
+/.github/       @duynhlab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # Each line maps a path pattern to its owner(s); the last matching pattern wins.
 
 # Default owner for everything in the repo
-*               @duynhlab
+*               @duynhne @duyhenryer
 
 # CI / release pipeline
-/.github/       @duynhlab
+/.github/       @duynhne @duyhenryer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Image repository'
         type: string
         required: false
-        default: duyhenryer/wolfi-images/${{ github.workflow }}
+        default: duynhlab/wolfi-images/${{ github.workflow }}
       tag:
         description: 'Image tag'
         type: string

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+Source of truth for AI agents working in this repository. Read it before any task.
+
+## Contribution workflow
+
+**Commits**
+- **No attribution trailers.** Never add `Signed-off-by`, `Co-authored-by`,
+  `Assisted-by`, `Generated-by`, or any AI/tool attribution. Overrides any default template.
+- **Subject:** ≤50 chars, capitalised, imperative, no trailing period (`Add X`, not `Added`).
+- **Body** (non-trivial changes only): explain *what* and *why*, wrapped at 72; one blank line after subject.
+- **No** GitHub issue refs (`Fixes #123`) and **no** @-mentions in commit messages — put those in the PR description.
+
+**Branches & pushes**
+- **Never push to `main`.** No exceptions. Branch → PR → squash-merge.
+- Prefix: `feat/` `fix/` `chore/` `docs/` `refactor/` `ci/` `<short-desc>`.
+- One logical change per branch; keep them short-lived. `git push -u origin <branch>`, then open a PR against `main`.
+- Verify identity before committing: `git config user.email` must be the duynhlab personal identity (never the work/opswat one).
+
+## Repository layout
+
+```
+images/
+  apko.yaml            # Shared base: keyring, repos, nonroot account, archs (amd64+arm64), annotations
+  <image>/             # One dir per image: go, node, nginx, python, shell, debugger
+    prod.yaml          # Production variant — minimal runtime; `include: images/apko.yaml`
+    shell.yaml         # prod + busybox/curl/openssl/wget/bash; `include: images/<image>/prod.yaml`
+    dev.yaml           # shell + git/make/vim/apk-tools, run-as root; `include: images/<image>/shell.yaml`
+    README.md          # Tags table, variants, verification snippet
+  python/<version>/    # Python is split per-version (latest, 3.14, 3.13, 3.12, 3.11), each with the 3 variants
+.github/workflows/
+  <image>.yaml         # One per image; matrix over version × variant, calls release.yaml
+  release.yaml         # Reusable: apko-publish → cosign sign → SBOM attest → build provenance
+  cleaner.yaml         # Weekly cleanup of old workflow runs
+.github/dependabot.yml
+```
+
+- **Variant inheritance:** `dev` → `shell` → `prod` → `apko.yaml`. Add packages at the lowest layer that needs them; never duplicate what a parent already pulls in.
+- Images publish to `ghcr.io/duynhlab/wolfi-images/<image>`.
+
+## Build, test, deploy
+
+- **Build tool:** [apko](https://github.com/chainguard-dev/apko) (declarative, no Dockerfile). Each `*.yaml` is a full image definition; there is no local source to compile.
+- **Local build/test** (requires `apko` + `docker`):
+  ```bash
+  apko build images/go/prod.yaml go:test go.tar && docker load < go.tar
+  docker run --rm go:test version
+  ```
+- **CI:** push to `main` (or `workflow_dispatch`, or weekday cron `00 01 * * 1-5`) touching `images/<image>/*.yaml` or the image's workflow triggers a matrix build over `version × {prod,shell,dev}`. Pinned versions are set via the `packages:` matrix input (e.g. `go~1.24`); `python` selects via `config-dir` per-version subdir instead.
+- **Registry routing:** `main` → `ghcr.io`; any other ref → `ttl.sh` (ephemeral, for PR/branch testing). Set in `release.yaml`'s *Set Vars* step.
+- **Supply chain:** every image is multi-arch (amd64+arm64), cosign-signed (keyless/OIDC), ships an SPDX SBOM attestation per arch, and (on `ghcr.io`) build-provenance attestation. Pin all action `uses:` to a commit SHA with a trailing `#vX` comment, matching the existing workflows.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 | 🏷️ Image Name | 📦 Pull Command |
 |---------------|----------------|
-| [**python**](./images/python/) | `docker pull ghcr.io/duyhenryer/wolfi-images/python` |
-| [**node**](./images/node/) | `docker pull ghcr.io/duyhenryer/wolfi-images/node` |
-| [**go**](./images/go/) | `docker pull ghcr.io/duyhenryer/wolfi-images/go` |
-| [**nginx**](./images/nginx/) | `docker pull ghcr.io/duyhenryer/wolfi-images/nginx` |
-| [**shell**](./images/shell/) | `docker pull ghcr.io/duyhenryer/wolfi-images/shell` |
+| [**python**](./images/python/) | `docker pull ghcr.io/duynhlab/wolfi-images/python` |
+| [**node**](./images/node/) | `docker pull ghcr.io/duynhlab/wolfi-images/node` |
+| [**go**](./images/go/) | `docker pull ghcr.io/duynhlab/wolfi-images/go` |
+| [**nginx**](./images/nginx/) | `docker pull ghcr.io/duynhlab/wolfi-images/nginx` |
+| [**shell**](./images/shell/) | `docker pull ghcr.io/duynhlab/wolfi-images/shell` |
 
 ## ✨ Features
 
@@ -25,14 +25,14 @@
 
 ```bash
 # Python version
-docker run --rm ghcr.io/duyhenryer/wolfi-images/python:latest --version
+docker run --rm ghcr.io/duynhlab/wolfi-images/python:latest --version
 
 # Node version  
-docker run --rm ghcr.io/duyhenryer/wolfi-images/node:latest --version
+docker run --rm ghcr.io/duynhlab/wolfi-images/node:latest --version
 
 # Nginx version
-docker run ghcr.io/duyhenryer/wolfi-images/nginx:latest -version
+docker run ghcr.io/duynhlab/wolfi-images/nginx:latest -version
 
 # Go version
-docker run ghcr.io/duyhenryer/wolfi-images/go:latest version
+docker run ghcr.io/duynhlab/wolfi-images/go:latest version
 ```

--- a/images/apko.yaml
+++ b/images/apko.yaml
@@ -24,4 +24,4 @@ archs:
 
 annotations:
   org.opencontainers.image.authors: 'Duy nè <hello@duyne.me>'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images'

--- a/images/debugger/README.md
+++ b/images/debugger/README.md
@@ -6,8 +6,8 @@
 
 | 📌 Version  | ⬇️ Pull URL                                         |
 | ---------- | -------------------------------------------------- |
-| latest     | ghcr.io/duyhenryer/wolfi-images/debugger:latest       |
-| latest-dev | ghcr.io/duyhenryer/wolfi-images/debugger:latest-shell |
+| latest     | ghcr.io/duynhlab/wolfi-images/debugger:latest       |
+| latest-dev | ghcr.io/duynhlab/wolfi-images/debugger:latest-shell |
 
 ## 📦 Variants
 
@@ -24,14 +24,14 @@ GitHub CLI ([gh](https://cli.github.com/)) can be used to retrieve the build pro
 
 ```shell
 gh attestation verify \
-  --owner duyhenryer \
-  oci://ghcr.io/duyhenryer/wolfi-images/debugger:latest
+  --owner duynhlab \
+  oci://ghcr.io/duynhlab/wolfi-images/debugger:latest
 ```
 
 - **Shell image**
 
 ```shell
 gh attestation verify \
-  --owner duyhenryer \
-  oci://ghcr.io/duyhenryer/wolfi-images/debugger:latest-shell
+  --owner duynhlab \
+  oci://ghcr.io/duynhlab/wolfi-images/debugger:latest-shell
 ```

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -6,21 +6,21 @@
 
 | ⬇️ Pull URL                                           | 📌 Version    |
 | ----------------------------------------------------- | ------------ |
-| ghcr.io/duyhenryer/wolfi-images/go:latest            | latest       |
-| ghcr.io/duyhenryer/wolfi-images/go:latest-dev        | latest-dev   |
-| ghcr.io/duyhenryer/wolfi-images/go:latest-shell      | latest-shell |
-| ghcr.io/duyhenryer/wolfi-images/go:1.25              | 1.25         |
-| ghcr.io/duyhenryer/wolfi-images/go:1.25-dev          | 1.25-dev     |
-| ghcr.io/duyhenryer/wolfi-images/go:1.25-shell        | 1.25-shell   |
-| ghcr.io/duyhenryer/wolfi-images/go:1.24              | 1.24         |
-| ghcr.io/duyhenryer/wolfi-images/go:1.24-dev          | 1.24-dev     |
-| ghcr.io/duyhenryer/wolfi-images/go:1.24-shell        | 1.24-shell   |
-| ghcr.io/duyhenryer/wolfi-images/go:1.23              | 1.23         |
-| ghcr.io/duyhenryer/wolfi-images/go:1.23-dev          | 1.23-dev     |
-| ghcr.io/duyhenryer/wolfi-images/go:1.23-shell        | 1.23-shell   |
-| ghcr.io/duyhenryer/wolfi-images/go:1.22              | 1.22         |
-| ghcr.io/duyhenryer/wolfi-images/go:1.22-dev          | 1.22-dev     |
-| ghcr.io/duyhenryer/wolfi-images/go:1.22-shell        | 1.22-shell   |
+| ghcr.io/duynhlab/wolfi-images/go:latest            | latest       |
+| ghcr.io/duynhlab/wolfi-images/go:latest-dev        | latest-dev   |
+| ghcr.io/duynhlab/wolfi-images/go:latest-shell      | latest-shell |
+| ghcr.io/duynhlab/wolfi-images/go:1.25              | 1.25         |
+| ghcr.io/duynhlab/wolfi-images/go:1.25-dev          | 1.25-dev     |
+| ghcr.io/duynhlab/wolfi-images/go:1.25-shell        | 1.25-shell   |
+| ghcr.io/duynhlab/wolfi-images/go:1.24              | 1.24         |
+| ghcr.io/duynhlab/wolfi-images/go:1.24-dev          | 1.24-dev     |
+| ghcr.io/duynhlab/wolfi-images/go:1.24-shell        | 1.24-shell   |
+| ghcr.io/duynhlab/wolfi-images/go:1.23              | 1.23         |
+| ghcr.io/duynhlab/wolfi-images/go:1.23-dev          | 1.23-dev     |
+| ghcr.io/duynhlab/wolfi-images/go:1.23-shell        | 1.23-shell   |
+| ghcr.io/duynhlab/wolfi-images/go:1.22              | 1.22         |
+| ghcr.io/duynhlab/wolfi-images/go:1.22-dev          | 1.22-dev     |
+| ghcr.io/duynhlab/wolfi-images/go:1.22-shell        | 1.22-shell   |
 
 ## 📦 Variants
 
@@ -34,14 +34,14 @@
 
 ```bash
 # Check if image is available
-docker manifest inspect ghcr.io/duyhenryer/wolfi-images/go:latest
+docker manifest inspect ghcr.io/duynhlab/wolfi-images/go:latest
 
 # Once available, check Go version
-docker run --rm ghcr.io/duyhenryer/wolfi-images/go:latest go version
+docker run --rm ghcr.io/duynhlab/wolfi-images/go:latest go version
 
 # Build and run Go application
 docker run --rm -v $(pwd):/app -w /app \
-  ghcr.io/duyhenryer/wolfi-images/go:latest-dev go run main.go
+  ghcr.io/duynhlab/wolfi-images/go:latest-dev go run main.go
 ```
 
 ## 🔐 Image Verification
@@ -50,7 +50,7 @@ All images are signed with Sigstore. Once images are published, verify authentic
 
 ```bash
 # Verify image signature (after successful build)
-cosign verify ghcr.io/duyhenryer/wolfi-images/go:latest \
-  --certificate-identity-regexp="https://github.com/duyhenryer/wolfi-images" \
+cosign verify ghcr.io/duynhlab/wolfi-images/go:latest \
+  --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/images/go/dev.yaml
+++ b/images/go/dev.yaml
@@ -14,4 +14,4 @@ accounts:
 annotations:
   org.opencontainers.image.title: 'go-dev'
   org.opencontainers.image.description: 'Go image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image/tree/main/images/go'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/go'

--- a/images/go/prod.yaml
+++ b/images/go/prod.yaml
@@ -44,4 +44,4 @@ cmd: version
 annotations:
   org.opencontainers.image.title: 'go'
   org.opencontainers.image.description: 'Go image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image/tree/main/images/go'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/go'

--- a/images/go/shell.yaml
+++ b/images/go/shell.yaml
@@ -11,4 +11,4 @@ contents:
 annotations:
   org.opencontainers.image.title: 'go-shell'
   org.opencontainers.image.description: 'Go image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image/tree/main/images/go'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/go'

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -6,21 +6,21 @@
 
 | ⬇️ Pull URL                                           | 📌 Version    |
 | ----------------------------------------------------- | ------------ |
-| ghcr.io/duyhenryer/wolfi-images/nginx:latest         | latest       |
-| ghcr.io/duyhenryer/wolfi-images/nginx:latest-dev     | latest-dev   |
-| ghcr.io/duyhenryer/wolfi-images/nginx:latest-shell   | latest-shell |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.29           | 1.29         |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.29-dev       | 1.29-dev     |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.29-shell     | 1.29-shell   |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.28           | 1.28         |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.28-dev       | 1.28-dev     |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.28-shell     | 1.28-shell   |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.27           | 1.27         |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.27-dev       | 1.27-dev     |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.27-shell     | 1.27-shell   |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.26           | 1.26         |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.26-dev       | 1.26-dev     |
-| ghcr.io/duyhenryer/wolfi-images/nginx:1.26-shell     | 1.26-shell   |
+| ghcr.io/duynhlab/wolfi-images/nginx:latest         | latest       |
+| ghcr.io/duynhlab/wolfi-images/nginx:latest-dev     | latest-dev   |
+| ghcr.io/duynhlab/wolfi-images/nginx:latest-shell   | latest-shell |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.29           | 1.29         |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.29-dev       | 1.29-dev     |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.29-shell     | 1.29-shell   |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.28           | 1.28         |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.28-dev       | 1.28-dev     |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.28-shell     | 1.28-shell   |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.27           | 1.27         |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.27-dev       | 1.27-dev     |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.27-shell     | 1.27-shell   |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.26           | 1.26         |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.26-dev       | 1.26-dev     |
+| ghcr.io/duynhlab/wolfi-images/nginx:1.26-shell     | 1.26-shell   |
 
 ## 📦 Variants
 
@@ -34,10 +34,10 @@
 
 ```bash
 # Check if image is available
-docker manifest inspect ghcr.io/duyhenryer/wolfi-images/nginx:1.29
+docker manifest inspect ghcr.io/duynhlab/wolfi-images/nginx:1.29
 
 # Once available, check nginx version
-docker run --rm --entrypoint /usr/sbin/nginx ghcr.io/duyhenryer/wolfi-images/nginx:1.29 -version
+docker run --rm --entrypoint /usr/sbin/nginx ghcr.io/duynhlab/wolfi-images/nginx:1.29 -version
 ```
 
 ## 🔐 Image Verification
@@ -46,7 +46,7 @@ All images are signed with Sigstore. Once images are published, verify authentic
 
 ```bash
 # Verify image signature (after successful build)
-cosign verify ghcr.io/duyhenryer/wolfi-images/nginx:1.29 \
-  --certificate-identity-regexp="https://github.com/duyhenryer/wolfi-images" \
+cosign verify ghcr.io/duynhlab/wolfi-images/nginx:1.29 \
+  --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/images/nginx/prod.yaml
+++ b/images/nginx/prod.yaml
@@ -58,4 +58,4 @@ stop-signal: SIGQUIT
 annotations:
   org.opencontainers.image.title: 'nginx'
   org.opencontainers.image.description: 'Nginx image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image/tree/main/images/nginx'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/nginx'

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -6,18 +6,18 @@
 
 | ⬇️ Pull URL                                           | 📌 Version    |
 | ----------------------------------------------------- | ------------ |
-| ghcr.io/duyhenryer/wolfi-images/node:latest          | latest       |
-| ghcr.io/duyhenryer/wolfi-images/node:latest-shell    | latest-shell |
-| ghcr.io/duyhenryer/wolfi-images/node:latest-dev      | latest-dev   |
-| ghcr.io/duyhenryer/wolfi-images/node:23              | 23           |
-| ghcr.io/duyhenryer/wolfi-images/node:23-shell        | 23-shell     |
-| ghcr.io/duyhenryer/wolfi-images/node:23-dev          | 23-dev       |
-| ghcr.io/duyhenryer/wolfi-images/node:22              | 22           |
-| ghcr.io/duyhenryer/wolfi-images/node:22-shell        | 22-shell     |
-| ghcr.io/duyhenryer/wolfi-images/node:22-dev          | 22-dev       |
-| ghcr.io/duyhenryer/wolfi-images/node:20              | 20           |
-| ghcr.io/duyhenryer/wolfi-images/node:20-shell        | 20-shell     |
-| ghcr.io/duyhenryer/wolfi-images/node:20-dev          | 20-dev       |
+| ghcr.io/duynhlab/wolfi-images/node:latest          | latest       |
+| ghcr.io/duynhlab/wolfi-images/node:latest-shell    | latest-shell |
+| ghcr.io/duynhlab/wolfi-images/node:latest-dev      | latest-dev   |
+| ghcr.io/duynhlab/wolfi-images/node:23              | 23           |
+| ghcr.io/duynhlab/wolfi-images/node:23-shell        | 23-shell     |
+| ghcr.io/duynhlab/wolfi-images/node:23-dev          | 23-dev       |
+| ghcr.io/duynhlab/wolfi-images/node:22              | 22           |
+| ghcr.io/duynhlab/wolfi-images/node:22-shell        | 22-shell     |
+| ghcr.io/duynhlab/wolfi-images/node:22-dev          | 22-dev       |
+| ghcr.io/duynhlab/wolfi-images/node:20              | 20           |
+| ghcr.io/duynhlab/wolfi-images/node:20-shell        | 20-shell     |
+| ghcr.io/duynhlab/wolfi-images/node:20-dev          | 20-dev       |
 
 ## 📦 Variants
 
@@ -31,10 +31,10 @@
 
 ```bash
 # Check if image is available
-docker manifest inspect ghcr.io/duyhenryer/wolfi-images/node:latest
+docker manifest inspect ghcr.io/duynhlab/wolfi-images/node:latest
 
 # Check Node.js version
-docker run --rm ghcr.io/duyhenryer/wolfi-images/node:latest --version
+docker run --rm ghcr.io/duynhlab/wolfi-images/node:latest --version
 ```
 
 ## 🔐 Image Verification
@@ -43,7 +43,7 @@ All images are signed with Sigstore. Once images are published, verify authentic
 
 ```bash
 # Verify image signature (after successful build)
-cosign verify ghcr.io/duyhenryer/wolfi-images/node:latest \
-  --certificate-identity-regexp="https://github.com/duyhenryer/wolfi-images" \
+cosign verify ghcr.io/duynhlab/wolfi-images/node:latest \
+  --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/images/node/prod.yaml
+++ b/images/node/prod.yaml
@@ -15,4 +15,4 @@ cmd: --help
 annotations:
   org.opencontainers.image.title: 'node'
   org.opencontainers.image.description: 'Node image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-image/tree/main/images/node'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/node'

--- a/images/python/README.md
+++ b/images/python/README.md
@@ -5,18 +5,18 @@
 ## 🏷️ Available Tags
 | ⬇️ Pull URL                                           | 📌 Version    |
 | ----------------------------------------------------- | ------------ |
-| ghcr.io/duyhenryer/wolfi-images/python:latest         | latest       |
-| ghcr.io/duyhenryer/wolfi-images/python:latest-shell   | latest-shell |
-| ghcr.io/duyhenryer/wolfi-images/python:latest-dev     | latest-dev   |
-| ghcr.io/duyhenryer/wolfi-images/python:3.13           | 3.13           |
-| ghcr.io/duyhenryer/wolfi-images/python:3.13-shell     | 3.13-shell     |
-| ghcr.io/duyhenryer/wolfi-images/python:3.13-dev       | 3.13-dev       |
-| ghcr.io/duyhenryer/wolfi-images/python:3.12           | 3.12           |
-| ghcr.io/duyhenryer/wolfi-images/python:3.12-shell     | 3.12-shell     |
-| ghcr.io/duyhenryer/wolfi-images/python:3.12-dev       | 3.12-dev       |
-| ghcr.io/duyhenryer/wolfi-images/python:3.11           | 3.11           |
-| ghcr.io/duyhenryer/wolfi-images/python:3.11-shell     | 3.11-shell     |
-| ghcr.io/duyhenryer/wolfi-images/python:3.11-dev       | 3.11-dev       |
+| ghcr.io/duynhlab/wolfi-images/python:latest         | latest       |
+| ghcr.io/duynhlab/wolfi-images/python:latest-shell   | latest-shell |
+| ghcr.io/duynhlab/wolfi-images/python:latest-dev     | latest-dev   |
+| ghcr.io/duynhlab/wolfi-images/python:3.13           | 3.13           |
+| ghcr.io/duynhlab/wolfi-images/python:3.13-shell     | 3.13-shell     |
+| ghcr.io/duynhlab/wolfi-images/python:3.13-dev       | 3.13-dev       |
+| ghcr.io/duynhlab/wolfi-images/python:3.12           | 3.12           |
+| ghcr.io/duynhlab/wolfi-images/python:3.12-shell     | 3.12-shell     |
+| ghcr.io/duynhlab/wolfi-images/python:3.12-dev       | 3.12-dev       |
+| ghcr.io/duynhlab/wolfi-images/python:3.11           | 3.11           |
+| ghcr.io/duynhlab/wolfi-images/python:3.11-shell     | 3.11-shell     |
+| ghcr.io/duynhlab/wolfi-images/python:3.11-dev       | 3.11-dev       |
 
 
 ## 📦 Variants
@@ -32,10 +32,10 @@
 
 ```bash
 # Check Python version
-docker run --rm ghcr.io/duyhenryer/wolfi-images/python:3.12 --version
+docker run --rm ghcr.io/duynhlab/wolfi-images/python:3.12 --version
 
 # Check installed packages (dev variant)
-docker run --rm ghcr.io/duyhenryer/wolfi-images/python:3.12-dev -m pip list
+docker run --rm ghcr.io/duynhlab/wolfi-images/python:3.12-dev -m pip list
 ```
 
 ## 🔐 Image Verification
@@ -44,7 +44,7 @@ All images are signed with Sigstore. Once images are published, verify authentic
 
 ```bash
 # Verify image signature (after successful build)
-cosign verify ghcr.io/duyhenryer/wolfi-images/python:3.12 \
-  --certificate-identity-regexp="https://github.com/duyhenryer/wolfi-images" \
+cosign verify ghcr.io/duynhlab/wolfi-images/python:3.12 \
+  --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/images/python/dev.yaml
+++ b/images/python/dev.yaml
@@ -16,4 +16,4 @@ accounts:
 annotations:
   org.opencontainers.image.title: 'python'
   org.opencontainers.image.description: 'Python development image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-images/tree/main/images/python'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/python'

--- a/images/python/prod.yaml
+++ b/images/python/prod.yaml
@@ -12,4 +12,4 @@ entrypoint:
 annotations:
   org.opencontainers.image.title: 'python'
   org.opencontainers.image.description: 'Python production image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-images/tree/main/images/python'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/python'

--- a/images/python/shell.yaml
+++ b/images/python/shell.yaml
@@ -11,4 +11,4 @@ contents:
 annotations:
   org.opencontainers.image.title: 'python'
   org.opencontainers.image.description: 'Python shell image based on Wolfi OS'
-  org.opencontainers.image.source: 'https://github.com/duyhenryer/wolfi-images/tree/main/images/python'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/python'

--- a/images/shell/README.md
+++ b/images/shell/README.md
@@ -6,8 +6,8 @@
 
 | ⬇️ Pull URL                                           | 📌 Version    |
 | ----------------------------------------------------- | ------------ |
-| ghcr.io/duyhenryer/wolfi-images/shell:latest         | latest       |
-| ghcr.io/duyhenryer/wolfi-images/shell:latest-dev     | latest-dev   |
+| ghcr.io/duynhlab/wolfi-images/shell:latest         | latest       |
+| ghcr.io/duynhlab/wolfi-images/shell:latest-dev     | latest-dev   |
 
 ## 📦 Variants
 
@@ -28,10 +28,10 @@
 
 ```bash
 # Check if image is available
-docker manifest inspect ghcr.io/duyhenryer/wolfi-images/shell:latest
+docker manifest inspect ghcr.io/duynhlab/wolfi-images/shell:latest
 
 # Once available, run interactive shell
-docker run --rm -it ghcr.io/duyhenryer/wolfi-images/shell:latest bash
+docker run --rm -it ghcr.io/duynhlab/wolfi-images/shell:latest bash
 ```
 
 ## 🔐 Image Verification
@@ -40,8 +40,8 @@ docker run --rm -it ghcr.io/duyhenryer/wolfi-images/shell:latest bash
 GitHub CLI (`gh`) can be used to retrieve the build provenance, which details the exact commit, workflow, and runner that produced the image:
 ```sh
 gh attestation verify \
-  --owner duyhenryer \
-  oci://ghcr.io/duyhenryer/wolfi-images/shell:latest-shell
+  --owner duynhlab \
+  oci://ghcr.io/duynhlab/wolfi-images/shell:latest-shell
 ```
 
 ✅ ***Verify the Image Signature***
@@ -50,7 +50,7 @@ All images are signed with `Sigstore`. Once images are published, verify authent
 
 ```bash
 # Verify image signature (after successful build)
-cosign verify ghcr.io/duyhenryer/wolfi-images/shell:latest \
-  --certificate-identity-regexp="https://github.com/duyhenryer/wolfi-images" \
+cosign verify ghcr.io/duynhlab/wolfi-images/shell:latest \
+  --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```

--- a/images/shell/prod.yaml
+++ b/images/shell/prod.yaml
@@ -20,4 +20,4 @@ entrypoint:
 annotations:
   org.opencontainers.image.title: 'shell'
   org.opencontainers.image.description: 'Shell image based on Wolfi OS'
-  org.opencontainers.image.source": 'https://github.com/duyhenryer/wolfi-image/tree/main/images/shell'
+  org.opencontainers.image.source: 'https://github.com/duynhlab/wolfi-images/tree/main/images/shell'


### PR DESCRIPTION
## What

The repo was transferred from the `duyhenryer` account to `duynhlab`. This points every owner reference at the new namespace.

| Reference class | Files |
|---|---|
| Image pull paths (`ghcr.io/duynhlab/...`) | root `README.md`, all `images/*/README.md` |
| Cosign `--certificate-identity-regexp` | go/node/nginx/python/shell READMEs |
| gh attestation `--owner` flag | debugger + shell READMEs |
| Reusable workflow `repository` default | `.github/workflows/release.yaml` |
| `org.opencontainers.image.source` annotations | all `images/*/*.yaml` + `AGENTS.md` |

## Why it matters

Cosign keyless signatures are now produced under `https://github.com/duynhlab/...`, so the verification regexps and the workflow repository default **must** match the new owner or signing/verification breaks.

## Also included

- Normalised the singular `wolfi-image` → `wolfi-images` in `image.source` annotations to match the real repo name.
- Fixed a stray quote in `images/shell/prod.yaml` (`image.source":` → `image.source:`).

## Intentionally unchanged

The personal melange repo `wolfi.duyne.me` and the author annotation `Duy nè <hello@duyne.me>` — these are not GitHub-owner references.