### PR TITLE
Re-pin delete-workflow-runs to live v2.1 SHA

### DIFF
--- a/.github/workflows/cleaner.yaml
+++ b/.github/workflows/cleaner.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@a848750987669744ecffad5e2d22a36ff4fe8197 # v2.1
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
## Problem

Dependabot's `actions` group update is failing ([run 28014900521](https://github.com/duynhlab/wolfi-images/actions/runs/28014900521)):

```
Error processing Mattraks/delete-workflow-runs (HelperSubprocessFailed)
error: no such commit a848750987669744ecffad5e2d22a36ff4fe8197
```

## Root cause

`cleaner.yaml` pinned `Mattraks/delete-workflow-runs@a848750…` (`# v2.1`). Upstream later **re-pointed the `v2.1` tag** to a new commit (`b3018382…`), orphaning the old SHA. Dependabot does a `--depth 1` shallow clone; the orphaned commit isn't reachable from any branch/tag tip, so `git` reports `no such commit` and the entire grouped update aborts.

Unrelated to the recent owner transfer — this is a pre-existing stale pin.

## Fix

Re-pin to `b3018382ca039b53d238908238bd35d1fb14f8ee`, the commit the `v2.1` / `v2.1.0` tag currently points to (verified via the GitHub tags API). Still SHA-pinned with a version comment, consistent with the other workflows.