### PR TITLE
Add Grype vulnerability scanning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,23 @@ jobs:
               echo "digest-arm64=''" >> $GITHUB_OUTPUT
           fi
 
+      - name: Scan image for vulnerabilities
+        if: inputs.scan == 'true'
+        id: scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 #v7.4.0
+        with:
+          image: ${{ steps.vars.outputs.registry }}/${{ inputs.repository }}@${{ steps.digest.outputs.digest }}
+          output-format: sarif
+          fail-build: false
+          severity-cutoff: medium
+
+      - name: Upload scan results to code scanning
+        if: inputs.scan == 'true' && steps.vars.outputs.registry == 'ghcr.io'
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 #v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: ${{ github.workflow }}-${{ inputs.tag }}
+
       - name: Sign image
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ docker run ghcr.io/duynhlab/wolfi-images/nginx:latest -version
 # Go version
 docker run ghcr.io/duynhlab/wolfi-images/go:latest version
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Every image is scanned in CI with [Grype](https://github.com/anchore/grype) and the results are uploaded to the repo's **Security → Code scanning** tab. Scan any image yourself:
+
+```bash
+grype ghcr.io/duynhlab/wolfi-images/python:latest
+```
+
+See each image's README for more scanning options (`--only-fixed`, `--fail-on`, JSON output, scan-by-digest).

--- a/images/debugger/README.md
+++ b/images/debugger/README.md
@@ -35,3 +35,34 @@ gh attestation verify \
   --owner duynhlab \
   oci://ghcr.io/duynhlab/wolfi-images/debugger:latest-shell
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/debugger:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/debugger@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/debugger:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/debugger:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/debugger:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -54,3 +54,34 @@ cosign verify ghcr.io/duynhlab/wolfi-images/go:latest \
   --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/go:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/go@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/go:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/go:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/go:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -50,3 +50,34 @@ cosign verify ghcr.io/duynhlab/wolfi-images/nginx:1.29 \
   --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/nginx:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/nginx@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/nginx:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/nginx:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/nginx:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -47,3 +47,34 @@ cosign verify ghcr.io/duynhlab/wolfi-images/node:latest \
   --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/node:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/node@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/node:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/node:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/node:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.

--- a/images/python/README.md
+++ b/images/python/README.md
@@ -48,3 +48,34 @@ cosign verify ghcr.io/duynhlab/wolfi-images/python:3.12 \
   --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/python:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/python@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/python:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/python:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/python:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.

--- a/images/shell/README.md
+++ b/images/shell/README.md
@@ -54,3 +54,34 @@ cosign verify ghcr.io/duynhlab/wolfi-images/shell:latest \
   --certificate-identity-regexp="https://github.com/duynhlab/wolfi-images" \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
+
+## 🛡️ Vulnerability Scanning
+
+Built on Wolfi OS to keep CVEs near zero. Scan any tag yourself with [Grype](https://github.com/anchore/grype):
+
+```bash
+# Full scan — list all CVEs
+grype ghcr.io/duynhlab/wolfi-images/shell:latest
+
+# Pin to an immutable digest
+grype ghcr.io/duynhlab/wolfi-images/shell@sha256:<digest>
+
+# JSON output (CI integration)
+grype ghcr.io/duynhlab/wolfi-images/shell:latest -o json
+
+# Only vulnerabilities that have a fix available
+grype ghcr.io/duynhlab/wolfi-images/shell:latest --only-fixed
+
+# Fail (non-zero exit) on high/critical — use as a CI/CD gate
+grype ghcr.io/duynhlab/wolfi-images/shell:latest --fail-on high
+```
+
+Expected result for a freshly built image:
+
+```text
+ ✔ Scanned for vulnerabilities     [0 vulnerability matches]
+   └── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
+No vulnerabilities found
+```
+
+> CI scans every published image automatically and uploads results to the repo's **Security → Code scanning** tab.


### PR DESCRIPTION
## What

Adds [Grype](https://github.com/anchore/grype) vulnerability scanning — both in CI and in the docs.

### CI (`.github/workflows/release.yaml`)
Implements the previously **declared-but-unused** `scan` input (and the already-present `security-events: write` permission). After an image is published, two steps run:

1. **Scan image for vulnerabilities** — `anchore/scan-action` scans the published digest, emits SARIF. `fail-build: false` → **report-only**.
2. **Upload scan results to code scanning** — uploads SARIF to the repo's **Security → Code scanning** tab (guarded to `ghcr.io`, i.e. skips `ttl.sh`/PR runs). `category` is unique per matrix job (`<image>-<tag>`) so results don't overwrite each other.

Report-only by design: scheduled rebuilds must not break when a new CVE is disclosed upstream. Per-image workflows need no change — they inherit the `scan` default of `true`. Both new actions are SHA-pinned (`anchore/scan-action@e1165082` v7.4.0, `github/codeql-action/upload-sarif@dd903d2e` v3), matching the repo's pinning convention.

### Docs
- A `## 🛡️ Vulnerability Scanning` section in every image README (scan a tag, scan by digest, `-o json`, `--only-fixed`, `--fail-on high`).
- A short scanning section in the root README.

## Verification
- `grype ghcr.io/duynhlab/wolfi-images/go:latest` → **No vulnerabilities found** (validated locally; full sweep of all images run).
- `release.yaml` passes `actionlint` and YAML parse; both pinned SHAs resolve via the GitHub API.

## Note
`debugger` isn't published under `duynhlab` yet (rebuilds on next workflow run); its README still gets the section, and the `:latest` tag will resolve after the next build.