### PR TITLE
Disable provenance storage record

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,8 +179,11 @@ jobs:
 
       - if: steps.vars.outputs.registry == 'ghcr.io'
         name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 #v3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 #v4.1.0
         with:
           subject-name: ${{ steps.vars.outputs.registry }}/${{ inputs.repository }}
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
+          # Storage records can only be created for org-owned repos; this is a
+          # user-owned repo, so disable to avoid a "no artifacts found" warning.
+          create-storage-record: false


### PR DESCRIPTION
## Why

Re-lands the storage-record fix that **missed the PR #83 merge** (it was pushed seconds after #83 was merged, so only the first commit of #83 reached `main`). The `Failed to persist storage record: no artifacts found` / `artifact-metadata:write` warnings are still firing on every job because of this gap.

## Root cause (recap)

`actions/attest-build-provenance` (the `a2bbfa25` pin is actually **v4.1.0**, comment was stale) emits an artifact-metadata storage record when `push-to-registry: true`. Per the action docs, **storage records are only supported for organization-owned repositories** — `duynhlab/wolfi-images` is **user-owned**, so the record can never be created (`no artifacts found`), and `artifact-metadata:write` would not help.

## Fix

`create-storage-record: false` on the attest step. The provenance attestation itself is unaffected (still signed + pushed to the registry). Stale `#v3` comment corrected to `#v4.1.0`.

`actionlint` clean.