### PR TITLE
Bump Go matrix to 1.26, drop EOL 1.22/1.23

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,19 +23,17 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "1.25", "1.24", "1.23", "1.22"]
+        version: [latest, "1.26", "1.25", "1.24"]
         variant: [prod, shell, dev]
         include:
           - version: latest
             packages: ''
+          - version: "1.26"
+            packages: 'go~1.26'
           - version: "1.25"
             packages: 'go~1.25'
           - version: "1.24"
             packages: 'go~1.24'
-          - version: "1.23"
-            packages: 'go~1.23'
-          - version: "1.22"
-            packages: 'go~1.22'
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
     uses: './.github/workflows/release.yaml'
     with:

--- a/images/go/README.md
+++ b/images/go/README.md
@@ -9,18 +9,15 @@
 | ghcr.io/duynhlab/wolfi-images/go:latest            | latest       |
 | ghcr.io/duynhlab/wolfi-images/go:latest-dev        | latest-dev   |
 | ghcr.io/duynhlab/wolfi-images/go:latest-shell      | latest-shell |
+| ghcr.io/duynhlab/wolfi-images/go:1.26              | 1.26         |
+| ghcr.io/duynhlab/wolfi-images/go:1.26-dev          | 1.26-dev     |
+| ghcr.io/duynhlab/wolfi-images/go:1.26-shell        | 1.26-shell   |
 | ghcr.io/duynhlab/wolfi-images/go:1.25              | 1.25         |
 | ghcr.io/duynhlab/wolfi-images/go:1.25-dev          | 1.25-dev     |
 | ghcr.io/duynhlab/wolfi-images/go:1.25-shell        | 1.25-shell   |
 | ghcr.io/duynhlab/wolfi-images/go:1.24              | 1.24         |
 | ghcr.io/duynhlab/wolfi-images/go:1.24-dev          | 1.24-dev     |
 | ghcr.io/duynhlab/wolfi-images/go:1.24-shell        | 1.24-shell   |
-| ghcr.io/duynhlab/wolfi-images/go:1.23              | 1.23         |
-| ghcr.io/duynhlab/wolfi-images/go:1.23-dev          | 1.23-dev     |
-| ghcr.io/duynhlab/wolfi-images/go:1.23-shell        | 1.23-shell   |
-| ghcr.io/duynhlab/wolfi-images/go:1.22              | 1.22         |
-| ghcr.io/duynhlab/wolfi-images/go:1.22-dev          | 1.22-dev     |
-| ghcr.io/duynhlab/wolfi-images/go:1.22-shell        | 1.22-shell   |
 
 ## 📦 Variants
 


### PR DESCRIPTION
## Why

The new Grype scan flagged that `go:1.22` and `go:1.23` ship **EOL Go toolchains** with unpatched critical stdlib CVEs (1.22: 5 critical / 40 high; 1.23: 3 critical / 37 high — unique CVEs). Go 1.26 is out (Feb 2026) and upstream supports only the two newest majors, so those versions will never be fixed.

## Change

Build matrix `latest, 1.26, 1.25, 1.24`:
- **add** `1.26` (`go~1.26`)
- **drop** EOL `1.22` and `1.23`
- keep `1.24`

`go-1.26` is confirmed available in the Wolfi repo (package definition in `wolfi-dev/os` + built binary `P:go-1.26` in the APKINDEX). README tag table updated to match. `actionlint` clean.

## Notes / follow-ups (not in this PR)

- **`1.24` is also upstream-EOL** (Wolfi keeps only 1.25/1.26 package definitions). Kept for now; candidate for a future drop.
- **Stale published tags:** `go:1.22*` / `go:1.23*` remain in GHCR until manually deleted — this PR only stops rebuilding them. Deleting published packages is destructive, so left as a separate explicit step.